### PR TITLE
TransactionTooLarge exception & onSaveInstanceState crash

### DIFF
--- a/folioreader/AndroidManifest.xml
+++ b/folioreader/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <application>
         <activity android:name=".activity.HighlightListActivity" />
         <activity android:name=".activity.ContentHighlightActivity" />
+        <activity android:name=".activity.FolioActivity" />
     </application>
 
 </manifest>

--- a/folioreader/src/main/java/com/folioreader/Constants.java
+++ b/folioreader/src/main/java/com/folioreader/Constants.java
@@ -1,13 +1,9 @@
 package com.folioreader;
 
-import com.squareup.otto.Bus;
-import com.squareup.otto.ThreadEnforcer;
-
 /**
  * Created by mobisys on 10/4/2016.
  */
 public class Constants {
-    public static final String BOOK = "book";
     public static final String SELECTED_CHAPTER_POSITION = "selected_chapter_position";
     public static final String TYPE = "type";
     public static final String CHAPTER_SELECTED = "chapter_selected";
@@ -17,4 +13,5 @@ public class Constants {
     public static final String VIEWPAGER_POSITION = "view_pager_position";
     public static final String BOOK_STATE = "book_state";
     public static final String CHARSET_NAME = "UTF-8";
+    public static final String BOOK_FILE_PATH = "book_file_path";
 }

--- a/folioreader/src/main/java/com/folioreader/activity/ContentHighlightActivity.java
+++ b/folioreader/src/main/java/com/folioreader/activity/ContentHighlightActivity.java
@@ -13,22 +13,21 @@ import com.folioreader.Constants;
 import com.folioreader.R;
 import com.folioreader.fragments.ContentsFragment;
 import com.folioreader.fragments.HighlightListFragment;
-import com.folioreader.util.AppUtil;
 import com.folioreader.util.UiUtil;
 
-import nl.siegmann.epublib.domain.Book;
-
 public class ContentHighlightActivity extends AppCompatActivity {
-    private Book mBook;
+    private String mBookTitle;
     private int mSelectedChapterPosition;
     private boolean mIsNightMode;
+    private String mBookPath;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_content_highlight);
         getSupportActionBar().hide();
-        mBook = (Book) getIntent().getSerializableExtra(Constants.BOOK);
+        mBookTitle = getIntent().getStringExtra(Constants.BOOK_TITLE);
+        mBookPath = getIntent().getStringExtra(Constants.BOOK_FILE_PATH);
         mSelectedChapterPosition = getIntent().getIntExtra(Constants.SELECTED_CHAPTER_POSITION, 0);
         mIsNightMode = Config.getConfig().isNightMode();
         initViews();
@@ -74,7 +73,7 @@ public class ContentHighlightActivity extends AppCompatActivity {
         findViewById(R.id.btn_contents).setSelected(true);
         findViewById(R.id.btn_highlights).setSelected(false);
         ContentsFragment contentFrameLayout
-                = ContentsFragment.newInstance(mBook, mSelectedChapterPosition);
+                = ContentsFragment.newInstance(mBookPath, mSelectedChapterPosition);
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
         ft.replace(R.id.parent, contentFrameLayout);
         ft.commit();
@@ -83,7 +82,7 @@ public class ContentHighlightActivity extends AppCompatActivity {
     private void loadHighlightsFragment() {
         findViewById(R.id.btn_contents).setSelected(false);
         findViewById(R.id.btn_highlights).setSelected(true);
-        HighlightListFragment highlightListFragment = HighlightListFragment.newInstance(mBook);
+        HighlightListFragment highlightListFragment = HighlightListFragment.newInstance(mBookTitle);
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
         ft.replace(R.id.parent, highlightListFragment);
         ft.commit();

--- a/folioreader/src/main/java/com/folioreader/activity/FolioActivity.java
+++ b/folioreader/src/main/java/com/folioreader/activity/FolioActivity.java
@@ -36,8 +36,6 @@ import com.folioreader.R;
 import com.folioreader.adapter.FolioPageFragmentAdapter;
 import com.folioreader.fragments.FolioPageFragment;
 import com.folioreader.model.Highlight;
-import com.folioreader.model.ReloadData;
-import com.folioreader.model.SmilElements;
 import com.folioreader.model.WebViewPosition;
 import com.folioreader.smil.AudioElement;
 import com.folioreader.smil.SmilFile;
@@ -60,7 +58,7 @@ import nl.siegmann.epublib.domain.Book;
 import nl.siegmann.epublib.domain.SpineReference;
 import nl.siegmann.epublib.domain.TOCReference;
 
-import static com.folioreader.Constants.BOOK;
+import static com.folioreader.Constants.BOOK_TITLE;
 import static com.folioreader.Constants.CHAPTER_SELECTED;
 import static com.folioreader.Constants.HIGHLIGHT_SELECTED;
 import static com.folioreader.Constants.SELECTED_CHAPTER_POSITION;
@@ -74,6 +72,7 @@ public class FolioActivity extends AppCompatActivity implements
     public static final int ACTION_CONTENT_HIGHLIGHT = 77;
     private static final String HIGHLIGHT_ITEM = "highlight_item";
     public static final Bus BUS = new Bus(ThreadEnforcer.ANY);
+    private String mBookeFilePath;
 
     public enum EpubSourceType {
         RAW,
@@ -144,7 +143,8 @@ public class FolioActivity extends AppCompatActivity implements
                 Intent intent = new Intent(FolioActivity.this, ContentHighlightActivity.class);
                 mBook.setResources(null);
                 mBook.setNcxResource(null);
-                intent.putExtra(BOOK, mBook);
+                intent.putExtra(BOOK_TITLE, mBook.getTitle());
+                intent.putExtra(Constants.BOOK_FILE_PATH, mBookeFilePath);
                 int TOCposition=AppUtil.getTOCpos(mTocReferences,mSpineReferences.get(mChapterPosition));
                 intent.putExtra(SELECTED_CHAPTER_POSITION, TOCposition);
                 startActivityForResult(intent, ACTION_CONTENT_HIGHLIGHT);
@@ -163,6 +163,7 @@ public class FolioActivity extends AppCompatActivity implements
             public void run() {
                 mBook = FileUtil.saveEpubFile(FolioActivity.this, mEpubSourceType, mEpubFilePath,
                         mEpubRawId, mEpubFileName);
+                mBookeFilePath = FileUtil.getFolioEpubFilePath(mEpubSourceType, mEpubFilePath, mEpubFileName);
                 runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
@@ -202,7 +203,7 @@ public class FolioActivity extends AppCompatActivity implements
             if (mBook != null && mSpineReferences != null) {
                 mFolioPageFragmentAdapter =
                         new FolioPageFragmentAdapter(getSupportFragmentManager(),
-                                mSpineReferences, mBook, mEpubFileName);
+                                mSpineReferences, mBook.getTitle(), mEpubFileName);
                 mFolioPageViewPager.setAdapter(mFolioPageFragmentAdapter);
                 mFolioPageViewPager.setOffscreenPageLimit(1);
                 mFolioPageViewPager.setCurrentItem(mChapterPosition);
@@ -212,7 +213,7 @@ public class FolioActivity extends AppCompatActivity implements
             if (mBook != null && mSpineReferences != null) {
                 mFolioPageFragmentAdapter =
                         new FolioPageFragmentAdapter(getSupportFragmentManager(),
-                                mSpineReferences, mBook, mEpubFileName);
+                                mSpineReferences, mBook.getTitle(), mEpubFileName);
                 mFolioPageViewPager.setAdapter(mFolioPageFragmentAdapter);
                 mFolioPageViewPager.setCurrentItem(mChapterPosition);
             }
@@ -281,7 +282,7 @@ public class FolioActivity extends AppCompatActivity implements
 
         if (mBook != null && mSpineReferences != null) {
             mFolioPageFragmentAdapter = new FolioPageFragmentAdapter(getSupportFragmentManager(),
-                    mSpineReferences, mBook, mEpubFileName);
+                    mSpineReferences, mBook.getTitle(), mEpubFileName);
             mFolioPageViewPager.setAdapter(mFolioPageFragmentAdapter);
             if (AppUtil.checkPreviousBookStateExist(FolioActivity.this, mBook)) {
                 mFolioPageViewPager.setCurrentItem(AppUtil.getPreviousBookStatePosition(FolioActivity.this, mBook));

--- a/folioreader/src/main/java/com/folioreader/activity/FolioActivity.java
+++ b/folioreader/src/main/java/com/folioreader/activity/FolioActivity.java
@@ -107,6 +107,10 @@ public class FolioActivity extends AppCompatActivity implements
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.folio_activity);
+        if (savedInstanceState == null) {
+            getSharedPreferences(FolioPageFragment.SP_FOLIO_PAGE_FRAGMENT, MODE_PRIVATE).edit().clear().apply();
+        }
+
         mEpubSourceType = (EpubSourceType)
                 getIntent().getExtras().getSerializable(FolioActivity.INTENT_EPUB_SOURCE_TYPE);
         if (mEpubSourceType.equals(EpubSourceType.RAW)) {

--- a/folioreader/src/main/java/com/folioreader/adapter/FolioPageFragmentAdapter.java
+++ b/folioreader/src/main/java/com/folioreader/adapter/FolioPageFragmentAdapter.java
@@ -4,7 +4,6 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
 
-import com.folioreader.Constants;
 import com.folioreader.activity.FolioActivity;
 import com.folioreader.fragments.FolioPageFragment;
 import com.folioreader.smil.TextElement;
@@ -13,32 +12,31 @@ import com.squareup.otto.Subscribe;
 import java.util.ArrayList;
 import java.util.List;
 
-import nl.siegmann.epublib.domain.Book;
 import nl.siegmann.epublib.domain.SpineReference;
 
 /**
  * Created by mahavir on 4/2/16.
  */
 public class FolioPageFragmentAdapter extends FragmentStatePagerAdapter {
+    private final String mBookTitle;
     private List<SpineReference> mSpineReferences;
-    private Book mBook;
     private String mEpubFileName;
     private FolioPageFragment mFolioPageFragment;
     private ArrayList<TextElement> mTextElementArrayList;
     private boolean mIsSmileAvailable;
 
     public FolioPageFragmentAdapter(FragmentManager fm, List<SpineReference> spineReferences,
-                                    Book book, String epubFilename) {
+                                    String bookTitle, String epubFilename) {
         super(fm);
         this.mSpineReferences = spineReferences;
-        this.mBook = book;
+        this.mBookTitle = bookTitle;
         this.mEpubFileName = epubFilename;
         FolioActivity.BUS.register(this);
     }
 
     @Override
     public Fragment getItem(int position) {
-        mFolioPageFragment = FolioPageFragment.newInstance(position, mBook, mEpubFileName, mTextElementArrayList, mIsSmileAvailable);
+        mFolioPageFragment = FolioPageFragment.newInstance(position, mBookTitle, mEpubFileName, mTextElementArrayList, mIsSmileAvailable);
         mFolioPageFragment.setFragmentPos(position);
         return mFolioPageFragment;
     }

--- a/folioreader/src/main/java/com/folioreader/fragments/ContentsFragment.java
+++ b/folioreader/src/main/java/com/folioreader/fragments/ContentsFragment.java
@@ -10,6 +10,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,32 +18,32 @@ import android.widget.TextView;
 
 import com.folioreader.Config;
 import com.folioreader.R;
+import com.folioreader.util.AppUtil;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import nl.siegmann.epublib.domain.Book;
 import nl.siegmann.epublib.domain.SpineReference;
 import nl.siegmann.epublib.domain.TOCReference;
 
-import static com.folioreader.Constants.BOOK;
 import static com.folioreader.Constants.CHAPTER_SELECTED;
 import static com.folioreader.Constants.SELECTED_CHAPTER_POSITION;
 import static com.folioreader.Constants.TYPE;
 
 
 public class ContentsFragment extends Fragment {
+    private static String BOOK_PATH = "book_path";
     private View mRootView;
     private Context mContext;
-    private ArrayList<TOCReference> mTocReferences;
+    private List<TOCReference> mTocReferences;
     private List<SpineReference> mSpineReferences;
     private int mSelectedChapterPosition;
     private boolean mIsNightMode;
 
-    public static ContentsFragment newInstance(Book book, int selectedChapterPosition) {
+    public static ContentsFragment newInstance(String bookPath, int selectedChapterPosition) {
         ContentsFragment contentsFragment = new ContentsFragment();
         Bundle args = new Bundle();
-        args.putSerializable(BOOK, book);
+        args.putString(BOOK_PATH, bookPath);
         args.putInt(SELECTED_CHAPTER_POSITION, selectedChapterPosition);
         contentsFragment.setArguments(args);
         return contentsFragment;
@@ -70,11 +71,13 @@ public class ContentsFragment extends Fragment {
 
 
     public void configRecyclerViews() {
-        Book book = (Book) getArguments().getSerializable(BOOK);
-        if (book != null) {
+        String bookPath = getArguments().getString(BOOK_PATH);
+
+        if (!TextUtils.isEmpty(bookPath)) {
+            Book book = AppUtil.saveBookToDb(bookPath);
             mSelectedChapterPosition
                     = getArguments().getInt(SELECTED_CHAPTER_POSITION);
-            mTocReferences = (ArrayList<TOCReference>) book.getTableOfContents().getTocReferences();
+            mTocReferences = book.getTableOfContents().getTocReferences();
             mSpineReferences
                     = book.getSpine().getSpineReferences();
             RecyclerView recyclerView

--- a/folioreader/src/main/java/com/folioreader/fragments/ContentsFragment.java
+++ b/folioreader/src/main/java/com/folioreader/fragments/ContentsFragment.java
@@ -144,9 +144,9 @@ public class ContentsFragment extends Fragment {
             holder.tocTitleView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    String title = mSpineReferences.get(position).getResource().getTitle();
+                    String title = mSpineReferences.get(position).getResource().getId();
                     for (int i = 0; i < mSpineReferences.size(); i++) {
-                        if (mSpineReferences.get(i).getResource().getTitle().equals(title)) {
+                        if (mSpineReferences.get(i).getResource().getId().equals(title)) {
                             mSelectedChapterPosition = i;
                             Intent intent = new Intent();
                             intent.putExtra(SELECTED_CHAPTER_POSITION, mSelectedChapterPosition);

--- a/folioreader/src/main/java/com/folioreader/fragments/FolioPageFragment.java
+++ b/folioreader/src/main/java/com/folioreader/fragments/FolioPageFragment.java
@@ -54,8 +54,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import nl.siegmann.epublib.domain.Book;
-
 
 /**
  * Created by mahavir on 4/2/16.
@@ -63,7 +61,7 @@ import nl.siegmann.epublib.domain.Book;
 public class FolioPageFragment extends Fragment {
 
     public static final String KEY_FRAGMENT_FOLIO_POSITION = "com.folioreader.fragments.FolioPageFragment.POSITION";
-    public static final String KEY_FRAGMENT_FOLIO_BOOK = "com.folioreader.fragments.FolioPageFragment.BOOK";
+    public static final String KEY_FRAGMENT_FOLIO_BOOK_TITLE = "com.folioreader.fragments.FolioPageFragment.BOOK_TITLE";
     public static final String KEY_FRAGMENT_EPUB_FILE_NAME = "com.folioreader.fragments.FolioPageFragment.EPUB_FILE_NAME";
     private static final String KEY_IS_SMIL_AVAILABLE = "com.folioreader.fragments.FolioPageFragment.IS_SMIL_AVAILABLE";
     public static final String TAG = FolioPageFragment.class.getSimpleName();
@@ -83,6 +81,7 @@ public class FolioPageFragment extends Fragment {
     private static final int ACTION_ID_HIGHLIGHT_UNDERLINE = 1011;
     private static final String KEY_TEXT_ELEMENTS = "text_elements";
     private WebViewPosition mWebviewposition;
+    private String mBookTitle;
 
 
     public static interface FolioPageFragmentCallback {
@@ -117,18 +116,17 @@ public class FolioPageFragment extends Fragment {
 
 
     private int mPosition = -1;
-    private Book mBook = null;
     private String mEpubFileName = null;
     private boolean mIsSmilAvailable;
     private int mPos;
     private boolean mIsPageReloaded;
     private int mLastWebviewScrollpos;
 
-    public static FolioPageFragment newInstance(int position, Book book, String epubFileName, ArrayList<TextElement> textElementArrayList, boolean isSmileAvailable) {
+    public static FolioPageFragment newInstance(int position, String bookTitle, String epubFileName, ArrayList<TextElement> textElementArrayList, boolean isSmileAvailable) {
         FolioPageFragment fragment = new FolioPageFragment();
         Bundle args = new Bundle();
         args.putInt(KEY_FRAGMENT_FOLIO_POSITION, position);
-        args.putSerializable(KEY_FRAGMENT_FOLIO_BOOK, book);
+        args.putString(KEY_FRAGMENT_FOLIO_BOOK_TITLE, bookTitle);
         args.putString(KEY_FRAGMENT_EPUB_FILE_NAME, epubFileName);
         args.putParcelableArrayList(KEY_TEXT_ELEMENTS, textElementArrayList);
         args.putBoolean(KEY_IS_SMIL_AVAILABLE, isSmileAvailable);
@@ -141,15 +139,15 @@ public class FolioPageFragment extends Fragment {
                              ViewGroup container, Bundle savedInstanceState) {
         if ((savedInstanceState != null)
                 && savedInstanceState.containsKey(KEY_FRAGMENT_FOLIO_POSITION)
-                && savedInstanceState.containsKey(KEY_FRAGMENT_FOLIO_BOOK)) {
+                && savedInstanceState.containsKey(KEY_FRAGMENT_FOLIO_BOOK_TITLE)) {
             mPosition = savedInstanceState.getInt(KEY_FRAGMENT_FOLIO_POSITION);
-            mBook = (Book) savedInstanceState.getSerializable(KEY_FRAGMENT_FOLIO_BOOK);
+            mBookTitle = savedInstanceState.getString(KEY_FRAGMENT_FOLIO_BOOK_TITLE);
             mEpubFileName = savedInstanceState.getString(KEY_FRAGMENT_EPUB_FILE_NAME);
             mIsSmilAvailable = savedInstanceState.getBoolean(KEY_IS_SMIL_AVAILABLE);
             mTextElementList = savedInstanceState.getParcelableArrayList(KEY_TEXT_ELEMENTS);
         } else {
             mPosition = getArguments().getInt(KEY_FRAGMENT_FOLIO_POSITION);
-            mBook = (Book) getArguments().getSerializable(KEY_FRAGMENT_FOLIO_BOOK);
+            mBookTitle = getArguments().getString(KEY_FRAGMENT_FOLIO_BOOK_TITLE);
             mEpubFileName = getArguments().getString(KEY_FRAGMENT_EPUB_FILE_NAME);
             mIsSmilAvailable = getArguments().getBoolean(KEY_IS_SMIL_AVAILABLE);
             mTextElementList = getArguments().getParcelableArrayList(KEY_TEXT_ELEMENTS);
@@ -241,7 +239,7 @@ public class FolioPageFragment extends Fragment {
                     if (mWebviewposition != null) {
                         setWebViewPosition(mWebviewposition.getWebviewPos());
                     } else if (!((FolioActivity) getActivity()).isbookOpened() && isCurrentFragment()) {
-                        setWebViewPosition(AppUtil.getPreviousBookStateWebViewPosition(mContext, mBook));
+                        setWebViewPosition(AppUtil.getPreviousBookStateWebViewPosition(mContext, mBookTitle));
                         ((FolioActivity) getActivity()).setIsbookOpened(true);
                     } else if (mIsPageReloaded) {
                         setWebViewPosition(mLastWebviewScrollpos);
@@ -495,7 +493,6 @@ public class FolioPageFragment extends Fragment {
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putInt(KEY_FRAGMENT_FOLIO_POSITION, mPosition);
-        outState.putSerializable(KEY_FRAGMENT_FOLIO_BOOK, mBook);
         outState.putString(KEY_FRAGMENT_EPUB_FILE_NAME, mEpubFileName);
     }
 
@@ -618,7 +615,7 @@ public class FolioPageFragment extends Fragment {
         }
 
         htmlContent = htmlContent.replace("<html ", "<html class=\"" + classes + "\" ");
-        ArrayList<Highlight> highlights = HighLightTable.getAllHighlights(mBook.getTitle());
+        ArrayList<Highlight> highlights = HighLightTable.getAllHighlights(mBookTitle);
         for (Highlight highlight : highlights) {
             String highlightStr =
                     "<highlight id=\"" + highlight.getHighlightId() +
@@ -815,7 +812,7 @@ public class FolioPageFragment extends Fragment {
     public void getHtmlAndSaveHighlight(String html) {
         if (html != null && mHighlightMap != null) {
             Highlight highlight =
-                    HighlightUtil.matchHighlight(html, mHighlightMap.get("id"), mBook, mPosition);
+                    HighlightUtil.matchHighlight(html, mHighlightMap.get("id"), mBookTitle, mPosition);
             highlight.setCurrentWebviewScrollPos(mWebview.getScrollY());
             highlight = ((FolioActivity) getActivity()).setCurrentPagerPostion(highlight);
             HighLightTable.insertHighlight(highlight);

--- a/folioreader/src/main/java/com/folioreader/fragments/HighlightListFragment.java
+++ b/folioreader/src/main/java/com/folioreader/fragments/HighlightListFragment.java
@@ -35,9 +35,7 @@ import com.folioreader.view.UnderlinedTextView;
 
 import java.util.ArrayList;
 
-import nl.siegmann.epublib.domain.Book;
-
-import static com.folioreader.Constants.BOOK;
+import static com.folioreader.Constants.BOOK_TITLE;
 import static com.folioreader.Constants.HIGHLIGHT_SELECTED;
 import static com.folioreader.Constants.TYPE;
 
@@ -45,13 +43,13 @@ public class HighlightListFragment extends Fragment {
     private static final String HIGHLIGHT_ITEM = "highlight_item";
     private View mRootView;
     private Context mContext;
-    private Book mBook;
+    private String mBookTitle;
 
 
-    public static HighlightListFragment newInstance(Book book) {
+    public static HighlightListFragment newInstance(String bookTitle) {
         HighlightListFragment fragment = new HighlightListFragment();
         Bundle args = new Bundle();
-        args.putSerializable(BOOK, book);
+        args.putString(BOOK_TITLE, bookTitle);
         fragment.setArguments(args);
         return fragment;
     }
@@ -66,7 +64,7 @@ public class HighlightListFragment extends Fragment {
                              ViewGroup container, Bundle savedInstanceState) {
         mRootView = inflater.inflate(R.layout.fragment_highlight_list, container, false);
         mContext = getActivity();
-        mBook = (Book) getArguments().getSerializable(BOOK);
+        mBookTitle = getArguments().getString(BOOK_TITLE);
         initViews();
         return mRootView;
     }
@@ -91,7 +89,7 @@ public class HighlightListFragment extends Fragment {
 
         HightlightAdpater hightlightAdpater =
                 new HightlightAdpater(mContext, 0,
-                        HighLightTable.getAllHighlights(mBook.getTitle()));
+                        HighLightTable.getAllHighlights(mBookTitle));
         ListView highlightListview = (ListView) mRootView.findViewById(R.id.list_highligts);
         highlightListview.setAdapter(hightlightAdpater);
     }

--- a/folioreader/src/main/java/com/folioreader/util/AppUtil.java
+++ b/folioreader/src/main/java/com/folioreader/util/AppUtil.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.util.Log;
 
 import com.folioreader.R;
-import com.folioreader.model.BookModel;
 import com.folioreader.smil.AudioElement;
 import com.folioreader.smil.SmilFile;
 import com.folioreader.smil.TextElement;
@@ -138,21 +137,13 @@ public class AppUtil {
         return ur1.equalsIgnoreCase(ur2);
     }
 
-    public static Book saveBookToDb(String epubFilePath, String epubFileName, Context context) {
+    public static Book saveBookToDb(String epubFilePath) {
         FileInputStream fs = null;
         Book book = null;
         try {
             fs = new FileInputStream(epubFilePath);
             book = (new EpubReader()).readEpub(fs);
-            fs = null;
-
-            BookModel bookModel = new BookModel();
-           /* book.setCoverImage(null);
-            book.setResources(null);*/
-           /* bookModel.setBook(book);
-            bookModel.setBookName(epubFileName);*/
-            //BookModelTable.createEntryInTableIfNotExist(context, bookModel);
-
+            fs.close();
         } catch (IOException e) {
             Log.d(TAG, e.getMessage());
         }
@@ -355,8 +346,8 @@ public class AppUtil {
         return 0;
     }
 
-    public static int getPreviousBookStateWebViewPosition(Context context, Book book) {
-        String json = getSharedPreferencesString(context, book.getTitle() + BOOK_STATE, null);
+    public static int getPreviousBookStateWebViewPosition(Context context, String bookTitle) {
+        String json = getSharedPreferencesString(context, bookTitle + BOOK_STATE, null);
         if (json != null) {
             try {
                 JSONObject jsonObject = new JSONObject(json);

--- a/folioreader/src/main/java/com/folioreader/util/FileUtil.java
+++ b/folioreader/src/main/java/com/folioreader/util/FileUtil.java
@@ -46,7 +46,7 @@ public class FileUtil {
                 }
 
                 new EpubManipulator(filePath, epubFileName, context);
-                book = AppUtil.saveBookToDb(filePath, epubFileName, context);
+                book = AppUtil.saveBookToDb(filePath);
             } else {
                 EpubManipulator epubManipulator= new EpubManipulator(filePath, epubFileName, context);
                 book = epubManipulator.getEpubBook();

--- a/folioreader/src/main/java/com/folioreader/util/HighlightUtil.java
+++ b/folioreader/src/main/java/com/folioreader/util/HighlightUtil.java
@@ -8,8 +8,6 @@ import java.util.Calendar;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import nl.siegmann.epublib.domain.Book;
-
 /**
  * Created by priyank on 5/12/16.
  */
@@ -17,7 +15,7 @@ public class HighlightUtil {
     public static final int mHighlightRange = 30;
     private static final String TAG = HighlightUtil.class.getSimpleName();
 
-    public static Highlight matchHighlight(String html, String highlightId, Book book, int pageNo) {
+    public static Highlight matchHighlight(String html, String highlightId, String bookTitle, int pageNo) {
         String contentPre = "";
         String contentPost = "";
         Highlight highlight = null;
@@ -54,7 +52,7 @@ public class HighlightUtil {
                 highlight.setContentPost(contentPost);
                 highlight.setHighlightId(highlightId);
                 highlight.setContent(matcher.group(2));
-                highlight.setBookId(book.getTitle());
+                highlight.setBookId(bookTitle);
                 highlight.setPage(pageNo);
                 highlight.setDate(Calendar.getInstance().getTime());
             }


### PR DESCRIPTION
Fixes:
* Pass the book file path to the interested fragments. Removed serialization of the book
    * ContentsFragment now loads the book from the file path
    * HighlightListFragment now reads only the title of the book. It doesn't require the rest
* Click in the Content section was causing a NullPointer because title is null. Replaced title with id.
* Rotation of the screen was causing the app to crash. The FolioPageFragment was causing the app to crash because it was requesting the getChapterHtmlContent from the activity while the book was not read. So I stored the HTML content in custom sharedprefs and got it out of there when savedInstanceState != null. Also removed the custom sharedprefs on app start.