### PR TITLE
Move EpubSourceType to FileUtil

### DIFF
--- a/folioreader/src/main/java/com/folioreader/ui/folio/activity/FolioActivity.java
+++ b/folioreader/src/main/java/com/folioreader/ui/folio/activity/FolioActivity.java
@@ -91,12 +91,6 @@ public class FolioActivity
     public static final String INTENT_EPUB_SOURCE_TYPE = "epub_source_type";
     public static final String INTENT_HIGHLIGHTS_LIST = "highlight_list";
 
-    public enum EpubSourceType {
-        RAW,
-        ASSETS,
-        SD_CARD
-    }
-
     private boolean isOpen = true;
 
     public static final int ACTION_CONTENT_HIGHLIGHT = 77;
@@ -123,7 +117,7 @@ public class FolioActivity
     private Config mConfig;
     private String mBookId;
     private String mEpubFilePath;
-    private EpubSourceType mEpubSourceType;
+    private FileUtil.EpubSourceType mEpubSourceType;
     int mEpubRawId = 0;
 
     @Override
@@ -132,9 +126,9 @@ public class FolioActivity
         setContentView(R.layout.folio_activity);
 
         mBookId = getIntent().getStringExtra(FolioReader.INTENT_BOOK_ID);
-        mEpubSourceType = (EpubSourceType)
+        mEpubSourceType = (FileUtil.EpubSourceType)
                 getIntent().getExtras().getSerializable(FolioActivity.INTENT_EPUB_SOURCE_TYPE);
-        if (mEpubSourceType.equals(EpubSourceType.RAW)) {
+        if (mEpubSourceType.equals(FileUtil.EpubSourceType.RAW)) {
             mEpubRawId = getIntent().getExtras().getInt(FolioActivity.INTENT_EPUB_SOURCE_PATH);
         } else {
             mEpubFilePath = getIntent().getExtras()
@@ -204,7 +198,7 @@ public class FolioActivity
         }
     }
 
-    private void initBook(String mEpubFileName, int mEpubRawId, String mEpubFilePath, EpubSourceType mEpubSourceType) {
+    private void initBook(String mEpubFileName, int mEpubRawId, String mEpubFilePath, FileUtil.EpubSourceType mEpubSourceType) {
         try {
             int portNumber = getIntent().getIntExtra(Config.INTENT_PORT, Constants.PORT_NUMBER);
             mEpubServer = EpubServerSingleton.getEpubServerInstance(portNumber);

--- a/folioreader/src/main/java/com/folioreader/util/FileUtil.java
+++ b/folioreader/src/main/java/com/folioreader/util/FileUtil.java
@@ -7,7 +7,6 @@ import android.os.Environment;
 import android.util.Log;
 
 import com.folioreader.Constants;
-import com.folioreader.ui.folio.activity.FolioActivity;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -23,7 +22,13 @@ public class FileUtil {
     private static final String TAG = FileUtil.class.getSimpleName();
     private static final String FOLIO_READER_ROOT = "/folioreader/";
 
-    public static String saveEpubFileAndLoadLazyBook(final Context context, FolioActivity.EpubSourceType epubSourceType, String epubFilePath, int epubRawId, String epubFileName) {
+    public enum EpubSourceType {
+        RAW,
+        ASSETS,
+        SD_CARD
+    }
+
+    public static String saveEpubFileAndLoadLazyBook(final Context context, EpubSourceType epubSourceType, String epubFilePath, int epubRawId, String epubFileName) {
         String filePath;
         InputStream epubInputStream;
         boolean isFolderAvailable;
@@ -32,10 +37,10 @@ public class FileUtil {
             filePath = getFolioEpubFilePath(epubSourceType, epubFilePath, epubFileName);
 
             if (!isFolderAvailable) {
-                if (epubSourceType.equals(FolioActivity.EpubSourceType.RAW)) {
+                if (epubSourceType.equals(EpubSourceType.RAW)) {
                     epubInputStream = context.getResources().openRawResource(epubRawId);
                     saveTempEpubFile(filePath, epubFileName, epubInputStream);
-                } else if (epubSourceType.equals(FolioActivity.EpubSourceType.ASSETS)) {
+                } else if (epubSourceType.equals(EpubSourceType.ASSETS)) {
                     AssetManager assetManager = context.getAssets();
                     epubFilePath = epubFilePath.replaceAll(Constants.ASSET, "");
                     epubInputStream = assetManager.open(epubFilePath);
@@ -57,8 +62,8 @@ public class FileUtil {
                 + "/" + FOLIO_READER_ROOT + "/" + epubFileName;
     }
 
-    public static String getFolioEpubFilePath(FolioActivity.EpubSourceType sourceType, String epubFilePath, String epubFileName) {
-        if (FolioActivity.EpubSourceType.SD_CARD.equals(sourceType)) {
+    public static String getFolioEpubFilePath(EpubSourceType sourceType, String epubFilePath, String epubFileName) {
+        if (EpubSourceType.SD_CARD.equals(sourceType)) {
             return epubFilePath;
         } else {
             return getFolioEpubFolderPath(epubFileName) + "/" + epubFileName + ".epub";
@@ -70,10 +75,10 @@ public class FileUtil {
         return file.isDirectory();
     }
 
-    public static String getEpubFilename(Context context, FolioActivity.EpubSourceType epubSourceType,
+    public static String getEpubFilename(Context context, EpubSourceType epubSourceType,
                                          String epubFilePath, int epubRawId) {
         String epubFileName;
-        if (epubSourceType.equals(FolioActivity.EpubSourceType.RAW)) {
+        if (epubSourceType.equals(EpubSourceType.RAW)) {
             Resources res = context.getResources();
             epubFileName = res.getResourceEntryName(epubRawId);
         } else {

--- a/folioreader/src/main/java/com/folioreader/util/FolioReader.java
+++ b/folioreader/src/main/java/com/folioreader/util/FolioReader.java
@@ -102,13 +102,13 @@ public class FolioReader {
         Intent intent = new Intent(context, FolioActivity.class);
         if (rawId != 0) {
             intent.putExtra(FolioActivity.INTENT_EPUB_SOURCE_PATH, rawId);
-            intent.putExtra(FolioActivity.INTENT_EPUB_SOURCE_TYPE, FolioActivity.EpubSourceType.RAW);
+            intent.putExtra(FolioActivity.INTENT_EPUB_SOURCE_TYPE, FileUtil.EpubSourceType.RAW);
         } else if (assetOrSdcardPath.contains(Constants.ASSET)) {
             intent.putExtra(FolioActivity.INTENT_EPUB_SOURCE_PATH, assetOrSdcardPath);
-            intent.putExtra(FolioActivity.INTENT_EPUB_SOURCE_TYPE, FolioActivity.EpubSourceType.ASSETS);
+            intent.putExtra(FolioActivity.INTENT_EPUB_SOURCE_TYPE, FileUtil.EpubSourceType.ASSETS);
         } else {
             intent.putExtra(FolioActivity.INTENT_EPUB_SOURCE_PATH, assetOrSdcardPath);
-            intent.putExtra(FolioActivity.INTENT_EPUB_SOURCE_TYPE, FolioActivity.EpubSourceType.SD_CARD);
+            intent.putExtra(FolioActivity.INTENT_EPUB_SOURCE_TYPE, FileUtil.EpubSourceType.SD_CARD);
         }
         return intent;
     }


### PR DESCRIPTION
EpubSourceType fits better into FileUtil in my opinion, because FileUtil should not access anything from the FolioActivity class if not really necessary.