### PR TITLE
Fix calling destroyed WebView

### DIFF
--- a/folioreader/src/main/java/com/folioreader/ui/folio/fragment/FolioPageFragment.java
+++ b/folioreader/src/main/java/com/folioreader/ui/folio/fragment/FolioPageFragment.java
@@ -15,7 +15,6 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.webkit.JavascriptInterface;
@@ -349,16 +348,16 @@ public class FolioPageFragment extends Fragment implements HtmlTaskCallback, Med
         }
 
         setupScrollBar();
-        mWebview.getViewTreeObserver().
-                addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
-                    @Override
-                    public void onGlobalLayout() {
-                        int height =
-                                (int) Math.floor(mWebview.getContentHeight() * mWebview.getScale());
-                        int webViewHeight = mWebview.getMeasuredHeight();
-                        mScrollSeekbar.setMaximum(height - webViewHeight);
-                    }
-                });
+        mWebview.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+            @Override
+            public void onLayoutChange(View view, int left, int top, int right, int bottom,
+                                       int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                int height =
+                        (int) Math.floor(mWebview.getContentHeight() * mWebview.getScale());
+                int webViewHeight = mWebview.getMeasuredHeight();
+                mScrollSeekbar.setMaximum(height - webViewHeight);
+            }
+        });
 
         mWebview.getSettings().setJavaScriptEnabled(true);
         mWebview.setVerticalScrollBarEnabled(false);


### PR DESCRIPTION
I replaced the `ViewTreeObserver.OnGlobalLayoutListener` with a `View.OnLayoutChangeListener` directly on the WebView.

This fixes errors like this where the Listener would not be removed when the WebView is destroyed and trying to call on it:
```
11-13 15:56:50.114 7331-7331/com.folioreader.android.sample W/cr_AwContents: Application attempted to call on a destroyed WebView
   java.lang.Throwable
       at org.chromium.android_webview.AwContents.isDestroyed(AwContents.java:338)
       at org.chromium.android_webview.AwContents.isDestroyedOrNoOperation(AwContents.java:311)
       at com.android.webview.chromium.WebViewChromium.getScale(WebViewChromium.java:308)
       at android.webkit.WebView.getScale(WebView.java:1331)
       at com.folioreader.ui.folio.fragment.FolioPageFragment$1.onGlobalLayout(FolioPageFragment.java:357)
       at android.view.ViewTreeObserver.dispatchOnGlobalLayout(ViewTreeObserver.java:945)
       at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2250)
       at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1392)
       at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:6752)
       at android.view.Choreographer$CallbackRecord.run(Choreographer.java:911)
       at android.view.Choreographer.doCallbacks(Choreographer.java:723)
       at android.view.Choreographer.doFrame(Choreographer.java:658)
       at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:897)
       at android.os.Handler.handleCallback(Handler.java:790)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:164)
       at android.app.ActivityThread.main(ActivityThread.java:6494)
       at java.lang.reflect.Method.invoke(Native Method)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
```

I have read that some people had issues with `View.OnLayoutChangeListener` and used the `ViewTreeObserver.OnGlobalLayoutListener` solution instead. I tested it and it seems to work fine in this case. If there is a reason why you specifically chose to do it like this, please let me know.