### PR TITLE
Add maven repository instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ Add following dependency to your app build.gradle
 compile 'com.folioreader:folioreader:0.3.2'
 ```
 
+Add maven repository to your top level build.gradle
+
+```groovy
+allprojects {
+    repositories {
+        maven { url "http://dl.bintray.com/mobisystech/maven" }
+    }
+}
+```
+
 ### Usage
 
 To use FolioReader, create object of **FolioReader** .


### PR DESCRIPTION
I've seen so many people with problems when trying to use the library because of not properly configuring the maven repository. I've had this problem myself too. So, I've decided to improve the repository Gradle documentation.