### PR TITLE
Fix heading bug in Style.css

### DIFF
--- a/folioreader/src/main/assets/css/Style.css
+++ b/folioreader/src/main/assets/css/Style.css
@@ -297,7 +297,7 @@ body {
     -webkit-hyphens: auto !important;
     hyphens: auto !important;
 }
-p, span, div {
+:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6) > p, span, div {
     font-size: 1rem;
     line-height: 1.5 !important;
 }


### PR DESCRIPTION
Fixes bug which causes certain chapter titles to be stylized incorrectly
(Compare chapter 2 to chapter 3: https://s3.amazonaws.com/moby-dick/moby-dick.epub)
Affects span elements within h1-6 elements