### PR TITLE
Fix NPE occurring when swiping fast between chapters

### DIFF
--- a/folioreader/src/main/java/com/folioreader/ui/fragment/FolioPageFragment.kt
+++ b/folioreader/src/main/java/com/folioreader/ui/fragment/FolioPageFragment.kt
@@ -319,7 +319,7 @@ class FolioPageFragment : Fragment(),
             uiHandler.post {
                 mWebview!!.loadDataWithBaseURL(
                     mActivityCallback?.streamerUrl + path,
-                    HtmlUtil.getHtmlContent(context!!, mHtmlString, mConfig!!),
+                    HtmlUtil.getHtmlContent(mWebview!!.context, mHtmlString, mConfig!!),
                     mimeType,
                     "UTF-8", null
                 )


### PR DESCRIPTION
If you swipe between chapters back and forth very fast - the app will crash. Variable `context` becomes null at some point. I fixed this by using context from `mWebview`.

How to reproduce this crash: https://youtu.be/Af8_L9MdgMk