### PR TITLE
FIX NPE thrown when fragment is destroyed before lastReadLocator is set

### DIFF
--- a/folioreader/src/main/java/com/folioreader/ui/fragment/FolioPageFragment.kt
+++ b/folioreader/src/main/java/com/folioreader/ui/fragment/FolioPageFragment.kt
@@ -838,7 +838,7 @@ class FolioPageFragment : Fragment(),
         if (isCurrentFragment) {
             if (outState != null)
                 outState!!.putSerializable(BUNDLE_READ_LOCATOR_CONFIG_CHANGE, lastReadLocator)
-            if (activity != null && !activity!!.isFinishing)
+            if (activity != null && !activity!!.isFinishing && lastReadLocator != null)
                 mActivityCallback!!.storeLastReadLocator(lastReadLocator)
         }
         if (mWebview != null) mWebview!!.destroy()


### PR DESCRIPTION
If you open the book and rotate device immediately the app will crash. Null pointer exception is thrown because FolioPageFragment is destroyed before lastReadLocator is set. Crash occurs at line 842.

How to reproduce this crash: https://youtu.be/kNfxIEmF-m4